### PR TITLE
FIX: Removed a space after `=` sign on line 273

### DIFF
--- a/after/plugin/match-count-statusline.vim
+++ b/after/plugin/match-count-statusline.vim
@@ -270,7 +270,8 @@ elseif !s:disable_statusline
   " add to statusline if it's not already added manually and if airline
   " doesn't exist
   if &statusline !~ 'MatchCountStatusline'
-    set laststatus = 2
+    " no space after `=` on the next line
+    set laststatus=2
     set ruler
     let &statusline = '%!MatchCountStatusline() ' . &statusline
   endif


### PR DESCRIPTION
Was getting an error:
```
Error detected while processing /home/user/.vim/bundle/match-count-statusline/after/plugin/match-count-statusline.vim:
line  273:
E521: Number required after =: laststatus =
```
after plugin installation.