### PR TITLE
Set statusline in a more standard way

### DIFF
--- a/after/plugin/match-count-statusline.vim
+++ b/after/plugin/match-count-statusline.vim
@@ -273,7 +273,7 @@ elseif !s:disable_statusline
     " no space after `=` on the next line
     set laststatus=2
     set ruler
-    let &statusline = '%!MatchCountStatusline() ' . &statusline
+    let &statusline = '%{MatchCountStatusline()} ' . &statusline
   endif
 endif
 


### PR DESCRIPTION
Evidently `%!` will just evaluate everything following as VimL.